### PR TITLE
fixed some bugs

### DIFF
--- a/jQuery.cssParentSelector.js
+++ b/jQuery.cssParentSelector.js
@@ -71,8 +71,7 @@
                         // There's nothing so we can skip this one.
                         if ( declarations === '{}' ) continue;
 
-                        // declarations = declarations.replace(/;/g, ' !important;');
-                        declarations = declarations.replace(/;/g, ';');
+                        declarations = declarations.replace(/;/g, ' !important;');
 
                         for (j = -1; selectors[++j], selector = $.trim(selectors[j]);) {
 


### PR DESCRIPTION
1. if the `dataType` of ajax has been set before, the `$.get` will not work property. fixed by changing it to `$.ajax`.
2. if the content of css rules contain brackets, (e.g. `background:url(xxx.jpg)`, the `REGEX` match will fail.
3. if `child` is a checkbox and the checkbox is `checked`, the status of class is wrong. fixed by toggle the class once more.
