### PR TITLE
fix a bug when there's no element on page 

### DIFF
--- a/jQuery.cssParentSelector.js
+++ b/jQuery.cssParentSelector.js
@@ -77,8 +77,6 @@
 
                         for (j = -1; selectors[++j], selector = $.trim(selectors[j]);) {
 
-                            // j && (parsed += ',');
-
                             if (/!/.test(selector) ) {
 
                                 // E! P > F => E


### PR DESCRIPTION
e.g.

```
input[checkbox]:checked{
    abc:abc;
}
```

when no checkbox on page, it will output:

```
/*some css 1*/

{
    abc:abc;
}

/*some css 2*/
```

thus makes 'some css 2' invaild.

Another case:

```
input[checkbox]:checked,input[checkbox]:disabled:checked{
    abc:abc;
}
```

if no checkbox is disabled, it will output:

```
/*some css 1*/

CPS0,CPS1,{
    abc:abc;
}

/*some css 2*/
```

makes the selector is invalid.
